### PR TITLE
Make the Host Environment Variable Optional

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
 LOCUST_CMD="/usr/local/bin/locust"
-LOCUST_OPTS="-f $SCENARIO_FILE --host=$TARGET_URL"
+LOCUST_OPTS="-f $SCENARIO_FILE"
 LOCUST_MODE=${LOCUST_MODE:-standalone}
+
+if [ "$TARGET_URL" != "" ]; then
+  LOCUST_OPTS="$LOCUST_OPTS --host=$TARGET_URL"
+fi
 
 if [ "$LOCUST_MODE" = "master" ]; then
   LOCUST_OPTS="$LOCUST_OPTS --master"


### PR DESCRIPTION
Locust will allow authors to override the host by specifying one in the Locust class definition. However, the ability to override this at runtime works only when no hostname has been specified on the command line. Even if the command line's value is blank, the presence of the option still blocks the runtime customization.

This PR allows one to omit the environment variable for the host and thus specify hosts within their scripts. If no environment variable is present, it simply skips adding the flag at startup.

@hakobera Thanks for a great tool!
