### PR TITLE
Install pyquery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:14.04
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential libncursesw5-dev libreadline-dev libssl-dev libgdbm-dev libc6-dev libsqlite3-dev libxml2-dev libxslt-dev python python-dev python-setuptools && apt-get clean
-RUN easy_install locustio pyzmq
+RUN easy_install locustio pyzmq pyquery
 
 ADD run.sh /usr/local/bin/run.sh
 RUN chmod 755 /usr/local/bin/run.sh


### PR DESCRIPTION
Added `pyquery` as installation argument to easy_install. This makes working with response-data a lot easier. Example: http://slides.com/jonatanheyman/load-testing-with-locust#/6
