### PR TITLE
Updated to Ubuntu 18.04 and pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,22 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential libncursesw5-dev libreadline-dev libssl-dev libgdbm-dev libc6-dev libsqlite3-dev libxml2-dev libxslt-dev python python-dev python-setuptools && apt-get clean
-RUN easy_install locustio pyzmq
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      build-essential \
+      libncursesw5-dev \
+      libreadline-dev \
+      libssl-dev \
+      libgdbm-dev \
+      libc6-dev \
+      libsqlite3-dev \
+      libxml2-dev \
+      libxslt-dev \
+      python \
+      python-dev \
+      python-setuptools \
+      python-pip \
+    && apt-get clean
+RUN pip install locustio pyzmq
 
 ADD run.sh /usr/local/bin/run.sh
 RUN chmod 755 /usr/local/bin/run.sh


### PR DESCRIPTION
This also gets us a newer version of locustio: 0.9.0.